### PR TITLE
Fixing __var_list__ issue for iterative

### DIFF
--- a/UnitTests/IterativeAnalysis/test_1.py
+++ b/UnitTests/IterativeAnalysis/test_1.py
@@ -1,9 +1,12 @@
 import os
 import sys
-sys.path.insert(1, "..\..")
-sys.path.insert(1, "..")
+baseDir = os.getcwd()
+sys.path.insert(1, os.path.join(baseDir, os.pardir))
+sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
+import DefaultUserInput as G #This is needed because we need the __var_list__
+MSRESOLVE_var_list = G.__var_list__ #need to store this to reassign in the new namespace.
     
 #get the suffix argument for check_results
 suffix = ut.returnDigitFromFilename(__file__)
@@ -45,16 +48,20 @@ if os.path.isfile('TotalConcentrations.csv'):
     os.remove('TotalConcentrations.csv')
 
 #NON ITERATIVE WAY FIRST.    
+MSRESOLVE_var_list = G.__var_list__ #need to store this to reassign in the new namespace.
 import test_1_initial_input_noniterative
 MSRESOLVE.G = test_1_initial_input_noniterative
+MSRESOLVE.G.__var_list__ = MSRESOLVE_var_list #need to repopulate var list since namespace was re-assigned.
 MSRESOLVE.main()
 
 #NOW DO THINGS THE ITERATIVE WAY.
 
 #ITERATION 1
 #now populate the globals with our first iteration's userinput.
+MSRESOLVE_var_list = G.__var_list__ #need to store this to reassign in the new namespace.
 import test_1_initial_input_iterative
 MSRESOLVE.G = test_1_initial_input_iterative
+MSRESOLVE.G.__var_list__ = MSRESOLVE_var_list #need to repopulate var list since namespace was re-assigned.
 #now run MSRESOLVE.py for the first iteration.
 MSRESOLVE.main()
 

--- a/UnitTests/IterativeAnalysis/test_1_initial_input_iterative.py
+++ b/UnitTests/IterativeAnalysis/test_1_initial_input_iterative.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, "..\..")
+sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 
@@ -229,14 +229,4 @@ TotalConcentrationsOutputName = 'TotalConcentrations.csv'
 ExportAtEachStep = 'yes'
 generatePercentages = 'no'
 
-__var_list__ = ['referenceFileNamesList','referenceFormsList','collectedFileName','referencePatternTimeRanges','iterativeAnalysis','iterationNumber','iterationSuffix','unusedMolecules','oldReferenceFileName', 'oldCollectedFileName', 'nextRefFileName', 'nextExpFileName','preProcessing','dataAnalysis','dataSimulation','grapher','timeRangeLimit','timeRangeStart','timeRangeFinish',
-				'specificMolecules','chosenMoleculesNames','specificMassFragments','chosenMassFragments','moleculeLikelihoods','sensitivityValues','linearBaselineCorrectionSemiAutomatic','baselineType','massesToBackgroundCorrect','earlyBaselineTimes','lateBaselineTimes',
-				'backgroundMassFragment','backgroundSlopes','backgroundIntercepts','interpolateYorN','marginalChangeRestriction','ignorableDeltaYThreshold','dataLowerBound','dataUpperBound',
-				'dataRangeSpecifierYorN','signalOrConcentrationRange','csvFile','moleculesToRestrict','csvFileName','bruteIncrements','permutationNum','maxPermutations','scaleRawDataOption','scaleRawDataFactor',
-				'measuredReferenceYorN','referenceMeasuredFileName','referenceLiteratureFileName','referenceCorrectionCoefficients','extractReferencePatternFromDataOption','rpcMoleculesToChange','rpcMoleculesToChangeMF',
-				'rpcTimeRanges','minimalReferenceValue','referenceValueThreshold','lowerBoundThresholdChooser','massesToLowerBoundThresholdFilter','lowerBoundThresholdPercentage','lowerBoundThresholdAbsolute',
-				'dataSmootherYorN','dataSmootherChoice','dataSmootherTimeRadius','dataSmootherPointRadius','dataSmootherHeadersToConfineTo','polynomialOrder','rawSignalThresholdMethod',
-				'rawSignalThresholdValue','sensitivityThresholdValue','rawSignalThresholdDivider','rawSignalThresholdLimit','rawSignalThresholdLimitPercent','negativeAnalyzerYorN','answer',
-				'uniqueOrCommon','slsFinish','bruteOption','distinguished','fullBrute','SLSUniqueExport','concentrationFinder','moleculesTSC_List','moleculeSignalTSC_List','massNumberTSC_List','moleculeConcentrationTSC_List',
-				'unitsTSC','preProcessedDataOutputName','resolvedScaledConcentrationsOutputName','scaledConcentrationsPercentages','concentrationsOutputName','simulatedSignalsOutputName','TotalConcentrationsOutputName',
-				'ExportAtEachStep','generatePercentages','checkpoint','start','timeSinceLastCheckpoint']
+#Below is where __var_list__ used to be.

--- a/UnitTests/IterativeAnalysis/test_1_initial_input_noniterative.py
+++ b/UnitTests/IterativeAnalysis/test_1_initial_input_noniterative.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, "..\..")
+sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 
@@ -230,14 +230,4 @@ TotalConcentrationsOutputName = 'TotalConcentrations.csv'
 ExportAtEachStep = 'yes'
 generatePercentages = 'no'
 
-__var_list__ = ['referenceFileNamesList','referenceFormsList','collectedFileName','referencePatternTimeRanges','iterativeAnalysis','iterationNumber','iterationSuffix','unusedMolecules','oldReferenceFileName', 'oldCollectedFileName', 'nextRefFileName', 'nextExpFileName','preProcessing','dataAnalysis','dataSimulation','grapher','timeRangeLimit','timeRangeStart','timeRangeFinish',
-				'specificMolecules','chosenMoleculesNames','specificMassFragments','chosenMassFragments','moleculeLikelihoods','sensitivityValues','linearBaselineCorrectionSemiAutomatic','baselineType','massesToBackgroundCorrect','earlyBaselineTimes','lateBaselineTimes',
-				'backgroundMassFragment','backgroundSlopes','backgroundIntercepts','interpolateYorN','marginalChangeRestriction','ignorableDeltaYThreshold','dataLowerBound','dataUpperBound',
-				'dataRangeSpecifierYorN','signalOrConcentrationRange','csvFile','moleculesToRestrict','csvFileName','bruteIncrements','permutationNum','maxPermutations','scaleRawDataOption','scaleRawDataFactor',
-				'measuredReferenceYorN','referenceMeasuredFileName','referenceLiteratureFileName','referenceCorrectionCoefficients','extractReferencePatternFromDataOption','rpcMoleculesToChange','rpcMoleculesToChangeMF',
-				'rpcTimeRanges','minimalReferenceValue','referenceValueThreshold','lowerBoundThresholdChooser','massesToLowerBoundThresholdFilter','lowerBoundThresholdPercentage','lowerBoundThresholdAbsolute',
-				'dataSmootherYorN','dataSmootherChoice','dataSmootherTimeRadius','dataSmootherPointRadius','dataSmootherHeadersToConfineTo','polynomialOrder','rawSignalThresholdMethod',
-				'rawSignalThresholdValue','sensitivityThresholdValue','rawSignalThresholdDivider','rawSignalThresholdLimit','rawSignalThresholdLimitPercent','negativeAnalyzerYorN','answer',
-				'uniqueOrCommon','slsFinish','bruteOption','distinguished','fullBrute','SLSUniqueExport','concentrationFinder','moleculesTSC_List','moleculeSignalTSC_List','massNumberTSC_List','moleculeConcentrationTSC_List',
-				'unitsTSC','preProcessedDataOutputName','resolvedScaledConcentrationsOutputName','scaledConcentrationsPercentages','concentrationsOutputName','simulatedSignalsOutputName','TotalConcentrationsOutputName',
-				'ExportAtEachStep','generatePercentages','checkpoint','start','timeSinceLastCheckpoint']
+#Below is where __var_list__ used to be.


### PR DESCRIPTION
I have fixed it so iterative no longer requires __var_list__ in the input files. Alex, please verify that tests pass, then merge this in. If any other unit test requires __var_list__, then change the test file to use the same strategy that I've implemented.