### PR TITLE
Convert import paths from absolute to relative

### DIFF
--- a/DefaultUserInput.py
+++ b/DefaultUserInput.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/MSRESOLVE.py
+++ b/MSRESOLVE.py
@@ -1376,10 +1376,10 @@ def SpecificIterationName(iterativeAnalysis, iterationNumber):
     if iterativeAnalysis == False or iterativeAnalysis == True:
          #create the default directory
          iterationDirectoryName = os.path.join(
-             os.getcwd(), "_iter_{}".format(str(iterationNumber)))
+             os.curdir, "_iter_{}".format(str(iterationNumber)))
     else:
         #set that name to be the directory along with the correct number 
-        iterationDirectoryName = os.path.join(os.getcwd(),
+        iterationDirectoryName = os.path.join(os.curdir,
             str(iterativeAnalysis),
              "_iter_{}".format(str(iterationNumber)))
     return iterationDirectoryName
@@ -1517,7 +1517,7 @@ def IADirandVarPopulation(iterativeAnalysis, chosenMassFragments, chosenMolecule
         #export reference data for next iteration
         if G.iterationNumber == 1: #first iteration files aren't in standard locations
             referenceFilePath = os.path.normpath(
-                os.path.join(os.getcwd(),
+                os.path.join(os.curdir,
                     os.pardir,
                     str(G.oldReferenceFileName[RefObjectIndex])))
             DataFunctions.TrimReferenceFileByMolecules(unusedMolecules,
@@ -1573,13 +1573,13 @@ def IterativeAnalysisPostProcessing(ExperimentData, simulateddata, mass_fragment
     if not G.iterativeAnalysis == True:
         iterationDirectoryName = '%s_iter_%s' %(G.iterativeAnalysis, str(G.iterationNumber - 1))
     #copy the experimental signals to the next iteration
-    copyFromPath = os.path.join(os.getcwd(), os.pardir,
+    copyFromPath = os.path.join(os.curdir, os.pardir,
             str(iterationDirectoryName),
             str(G.collectedFileName))
     shutil.copy(copyFromPath, os.getcwd())
     for RefIndex, RefName in enumerate(G.referenceFileNamesList): #a list
         #copy the next reference file from the previous iteration folder to the next iteration folder
-        copyFromPath = os.path.join(os.getcwd(),
+        copyFromPath = os.path.join(os.curdir,
             os.pardir,
             str(iterationDirectoryName),
             str(G.referenceFileNamesList[RefIndex]))

--- a/UnitTests/BestMassFragmentChooser/test_1.py
+++ b/UnitTests/BestMassFragmentChooser/test_1.py
@@ -8,10 +8,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 
 #BELOW ARE THE LINES INTENDED TO BE CHANGED BY THE USER	

--- a/UnitTests/BestMassFragmentChooser/test_2.py
+++ b/UnitTests/BestMassFragmentChooser/test_2.py
@@ -8,10 +8,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 
 #BELOW ARE THE LINES INTENDED TO BE CHANGED BY THE USER	

--- a/UnitTests/BestMassFragmentChooser/test_3.py
+++ b/UnitTests/BestMassFragmentChooser/test_3.py
@@ -8,10 +8,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 
 #BELOW ARE THE LINES INTENDED TO BE CHANGED BY THE USER	

--- a/UnitTests/DataSmoother/test_1.py
+++ b/UnitTests/DataSmoother/test_1.py
@@ -7,10 +7,9 @@ Created on Wed Nov 22 16:14:43 2017
 #THE FOLLOWING LINES ARE MANDATORY FOR THE CODE
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #importing the functions from UnitTesterSG module
 import UnitTesterSG as ut
 

--- a/UnitTests/DataSmoother/test_2.py
+++ b/UnitTests/DataSmoother/test_2.py
@@ -7,10 +7,9 @@ Created on Wed Nov 22 16:14:43 2017
 #THE FOLLOWING LINES ARE MANDATORY FOR THE CODE
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #importing the functions from UnitTesterSG module
 import UnitTesterSG as ut
 

--- a/UnitTests/ExtractReferencePatternFromData/test_1.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_1.py
@@ -6,10 +6,9 @@ Created on Wed Jul 11 13:26:37 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #This test file tests the extractReferencePatternFromData feature
 
 import MSRESOLVE

--- a/UnitTests/ExtractReferencePatternFromData/test_1_input.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_1_input.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ExtractReferencePatternFromData/test_2.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_2.py
@@ -6,10 +6,9 @@ Created on Wed Jul 11 13:26:37 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #This test file tests the extractReferencePatternFromData feature
 
 import MSRESOLVE

--- a/UnitTests/ExtractReferencePatternFromData/test_2_input.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_2_input.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ExtractReferencePatternFromData/test_3.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_3.py
@@ -6,10 +6,9 @@ Created on Wed Jul 11 13:26:37 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #This test file tests the extractReferencePatternFromData feature
 
 import MSRESOLVE

--- a/UnitTests/ExtractReferencePatternFromData/test_3_input.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_3_input.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ExtractReferencePatternFromData/test_4.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_4.py
@@ -6,10 +6,9 @@ Created on Wed Jul 11 13:26:37 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #This test file tests the extractReferencePatternFromData feature
 
 import MSRESOLVE

--- a/UnitTests/ExtractReferencePatternFromData/test_4_input.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_4_input.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ExtractReferencePatternFromData/test_5.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_5.py
@@ -6,10 +6,9 @@ Created on Wed Jul 11 13:26:37 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #This test file tests the extractReferencePatternFromData feature
 
 import MSRESOLVE

--- a/UnitTests/ExtractReferencePatternFromData/test_5_input.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_5_input.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ExtractReferencePatternFromData/test_6.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_6.py
@@ -6,10 +6,9 @@ Created on Wed Jul 11 13:26:37 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #This test file tests the extractReferencePatternFromData feature
 
 import MSRESOLVE

--- a/UnitTests/ExtractReferencePatternFromData/test_6_input.py
+++ b/UnitTests/ExtractReferencePatternFromData/test_6_input.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ImportantAbcissaIdentifier/test_1.py
+++ b/UnitTests/ImportantAbcissaIdentifier/test_1.py
@@ -8,10 +8,9 @@ Created on Mon Jul  2 14:16:13 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG 
 import numpy
 

--- a/UnitTests/ImportantAbcissaIdentifier/test_2.py
+++ b/UnitTests/ImportantAbcissaIdentifier/test_2.py
@@ -8,10 +8,9 @@ Created on Mon Jul  2 14:16:13 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG 
 import numpy
 

--- a/UnitTests/ImportantAbcissaIdentifier/test_3.py
+++ b/UnitTests/ImportantAbcissaIdentifier/test_3.py
@@ -8,10 +8,9 @@ Created on Mon Jul  2 14:16:13 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG 
 import numpy
 

--- a/UnitTests/ImportantAbcissaIdentifier/test_4.py
+++ b/UnitTests/ImportantAbcissaIdentifier/test_4.py
@@ -8,10 +8,9 @@ Created on Mon Jul  2 14:16:13 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG 
 import numpy
 

--- a/UnitTests/ImportantAbcissaIdentifier/test_5.py
+++ b/UnitTests/ImportantAbcissaIdentifier/test_5.py
@@ -8,10 +8,9 @@ Created on Mon Jul  2 14:16:13 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG 
 import numpy
 

--- a/UnitTests/IterativeAnalysis/test_1.py
+++ b/UnitTests/IterativeAnalysis/test_1.py
@@ -1,8 +1,7 @@
 import os
 import sys
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
 import DefaultUserInput as G #This is needed because we need the __var_list__

--- a/UnitTests/IterativeAnalysis/test_1_initial_input_iterative.py
+++ b/UnitTests/IterativeAnalysis/test_1_initial_input_iterative.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/IterativeAnalysis/test_1_initial_input_noniterative.py
+++ b/UnitTests/IterativeAnalysis/test_1_initial_input_noniterative.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/KeepOnlySelectedYYYYColumns/test_1.py
+++ b/UnitTests/KeepOnlySelectedYYYYColumns/test_1.py
@@ -6,10 +6,9 @@ Created on Tue Jun 12 14:07:44 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
 

--- a/UnitTests/KeepOnlySelectedYYYYColumns/test_2.py
+++ b/UnitTests/KeepOnlySelectedYYYYColumns/test_2.py
@@ -6,10 +6,9 @@ Created on Tue Jun 12 14:07:44 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
 

--- a/UnitTests/MarginalChangeRestrictor/test_1.py
+++ b/UnitTests/MarginalChangeRestrictor/test_1.py
@@ -5,10 +5,9 @@ Created on Wed Jun 13 08:07:13 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
 #import your function

--- a/UnitTests/MarginalChangeRestrictor/test_2.py
+++ b/UnitTests/MarginalChangeRestrictor/test_2.py
@@ -5,10 +5,9 @@ Created on Wed Jun 13 08:07:13 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
 #import your function

--- a/UnitTests/MarginalChangeRestrictor/test_3.py
+++ b/UnitTests/MarginalChangeRestrictor/test_3.py
@@ -5,10 +5,9 @@ Created on Wed Jun 13 08:07:13 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
 #import your function

--- a/UnitTests/MarginalChangeRestrictor/test_4.py
+++ b/UnitTests/MarginalChangeRestrictor/test_4.py
@@ -5,10 +5,9 @@ Created on Wed Jun 13 08:07:13 2018
 """
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
 #import your function

--- a/UnitTests/ReferencePatternTimeChooser/test_1.py
+++ b/UnitTests/ReferencePatternTimeChooser/test_1.py
@@ -7,10 +7,9 @@ Created on Wed Jul 18 15:20:19 2018
 
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #This test file tests the ReferencePatternTimeChooser feature
 
 import MSRESOLVE

--- a/UnitTests/ReferencePatternTimeChooser/test_1_inputA.py
+++ b/UnitTests/ReferencePatternTimeChooser/test_1_inputA.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ReferencePatternTimeChooser/test_1_inputB.py
+++ b/UnitTests/ReferencePatternTimeChooser/test_1_inputB.py
@@ -1,6 +1,6 @@
 import sys
 import os
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ReferencePatternTimeChooser/test_1_inputC.py
+++ b/UnitTests/ReferencePatternTimeChooser/test_1_inputC.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/ReferencePatternTimeChooser/test_2.py
+++ b/UnitTests/ReferencePatternTimeChooser/test_2.py
@@ -8,9 +8,9 @@ Created on Wed Jul 18 15:20:19 2018
 import sys
 import os
 baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #This test file tests the ReferencePatternTimeChooser feature
 
 import MSRESOLVE

--- a/UnitTests/ReferencePatternTimeChooser/test_2_input.py
+++ b/UnitTests/ReferencePatternTimeChooser/test_2_input.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UnitTests/RoughUniquenessCheck/test_1.py
+++ b/UnitTests/RoughUniquenessCheck/test_1.py
@@ -9,10 +9,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 
 #BELOW ARE THE LINES INTENDED TO BE CHANGED BY THE USER	

--- a/UnitTests/RoughUniquenessCheck/test_2.py
+++ b/UnitTests/RoughUniquenessCheck/test_2.py
@@ -9,10 +9,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 
 #BELOW ARE THE LINES INTENDED TO BE CHANGED BY THE USER	

--- a/UnitTests/RoughUniquenessCheck/test_3.py
+++ b/UnitTests/RoughUniquenessCheck/test_3.py
@@ -9,10 +9,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 
 #BELOW ARE THE LINES INTENDED TO BE CHANGED BY THE USER	

--- a/UnitTests/RoughUniquenessCheck/test_4.py
+++ b/UnitTests/RoughUniquenessCheck/test_4.py
@@ -9,10 +9,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 
 #BELOW ARE THE LINES INTENDED TO BE CHANGED BY THE USER	

--- a/UnitTests/SignificanceFactorCheck/test_1.py
+++ b/UnitTests/SignificanceFactorCheck/test_1.py
@@ -9,10 +9,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 
 import UnitTesterSG as ut
 import numpy

--- a/UnitTests/SignificanceFactorCheck/test_2.py
+++ b/UnitTests/SignificanceFactorCheck/test_2.py
@@ -9,10 +9,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 import numpy
 

--- a/UnitTests/SignificanceFactorCheck/test_3.py
+++ b/UnitTests/SignificanceFactorCheck/test_3.py
@@ -9,10 +9,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 
 import UnitTesterSG as ut
 import numpy

--- a/UnitTests/SignificanceFactorCheck/test_4.py
+++ b/UnitTests/SignificanceFactorCheck/test_4.py
@@ -9,10 +9,9 @@ Created on Wed Aug  1 13:47:18 2018
 #importing the functions from UnitTesterSG module
 import sys
 import os
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir, "lib"))
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, "lib"))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 import UnitTesterSG as ut
 import numpy
 

--- a/UnitTests/excludeMoleculesIfSignificantFragmentNotObserved/test_1.py
+++ b/UnitTests/excludeMoleculesIfSignificantFragmentNotObserved/test_1.py
@@ -1,8 +1,7 @@
 import os
 import sys
-baseDir = os.getcwd()
-sys.path.insert(1, os.path.join(baseDir, os.pardir))
-sys.path.insert(1, os.path.join(baseDir, os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 #import the functions from UnitTesterSG
 import UnitTesterSG as ut
     

--- a/UnitTests/excludeMoleculesIfSignificantFragmentNotObserved/test_1_input.py
+++ b/UnitTests/excludeMoleculesIfSignificantFragmentNotObserved/test_1_input.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 

--- a/UserInput.py
+++ b/UserInput.py
@@ -1,6 +1,6 @@
 import os
 import sys 
-sys.path.insert(1, os.path.join(os.getcwd(), os.pardir, os.pardir))
+sys.path.insert(1, os.path.join(os.curdir, os.pardir, os.pardir))
 if os.path.basename(__file__) != "DefaultUserInput.py":
     from DefaultUserInput import *
 


### PR DESCRIPTION
The import paths for all of the testing were absolute, they
have been converted to relative paths now. This has been
tested on Ubuntu and Windows and all tests run on both.